### PR TITLE
Fix generate argument

### DIFF
--- a/source/_posts/2017/2017-02-20-statie-how-to-run-it-locally.md
+++ b/source/_posts/2017/2017-02-20-statie-how-to-run-it-locally.md
@@ -82,7 +82,7 @@ layout: default
 Run in project root in CLI:
 
 ```bash
-vendor/bin/statie generate
+vendor/bin/statie generate source/
 ```
 
 ## 3. See Generate Code


### PR DESCRIPTION
Error:
```
  [Symfony\Component\Console\Exception\RuntimeException]
  Not enough arguments (missing: "source").
```