### PR TITLE
Add Deprecated and Czech posts section

### DIFF
--- a/source/_posts/2015/2015-11-02-ovladni-doctrine-migrace-v-nette.md
+++ b/source/_posts/2015/2015-11-02-ovladni-doctrine-migrace-v-nette.md
@@ -12,6 +12,8 @@ deprecated_message: '''
     <br><br>
     It is still available <a href="https://github.com/DeprecatedPackages/DoctrineMigrations">here for inspiration</a> though.
 '''
+
+lang: cs
 ---
 
 Stejně jako Kdyby/Doctrine využívá doctrine/doctrine2, my použijeme [doctrine/migrations](https://github.com/doctrine/migrations). Ty si [denně stáhne přes 9 000 programátorů](https://packagist.org/packages/doctrine/migrations/stats), takže se nemusíte bát o jeho kvalitu.

--- a/source/_posts/2015/2015-11-09-4-zhave-novinky-v-symfony-3.md
+++ b/source/_posts/2015/2015-11-09-4-zhave-novinky-v-symfony-3.md
@@ -8,6 +8,8 @@ related_posts: [4]
 deprecated: true
 deprecated_since: "August 2017"
 deprecated_message: "This post is available only in Czech and whole website was moved to English."
+
+lang: cs
 ---
 
 Symfony už toho umí opravdu hodně. Nová verze klade velký důraz především na [DX (developer experience)](http://symfony.com/blog/making-the-symfony-experience-exceptional). Přináší nám **jednodušší a jednoznačné API**, **lepší decoupling komponent**, **integraci standardů [PSR-3](http://www.php-fig.org/psr/psr-3/) a [PSR-7](http://symfony.com/doc/current/cookbook/psr7.html)**. A spoustu dalších novinek, díky kterým bude psaní aplikací zase o něco zábavnější.

--- a/source/_posts/2015/2015-11-16-jak-si-udelat-web-i-bez-ajtaka.md
+++ b/source/_posts/2015/2015-11-16-jak-si-udelat-web-i-bez-ajtaka.md
@@ -7,6 +7,8 @@ perex: "Znáš pojmy jako hosting, doména, HTML, CSS, FTP, šablona, Wordpress 
 deprecated: true
 deprecated_since: "August 2017"
 deprecated_message: "This post is available only in Czech and whole website was moved to English."
+
+lang: cs
 ---
 
 Na [MyEagers konferenci](http://myeagers.beeager.com/) jsem se stal svědkem workshopu [Lekce svádění aneb jak to udělat online tak, aby Tě chtěli](https://www.facebook.com/events/885079758208224/permalink/896505960398937/). **Kopa šikovných hacků, které ti dají světelný náskok na tvé pracovní cestě**.

--- a/source/_posts/2015/2015-12-20-to-nejlepsi-ze-symfonyconu-2015.md
+++ b/source/_posts/2015/2015-12-20-to-nejlepsi-ze-symfonyconu-2015.md
@@ -6,6 +6,8 @@ related_posts: [2]
 deprecated: true
 deprecated_since: "August 2017"
 deprecated_message: "This post is available only in Czech and whole website was moved to English."
+
+lang: cs
 ---
 
 <div class="text-center">

--- a/source/_posts/2016/2016-12-09-jak-se-vyporadat-s-hejty-v-komentarich.md
+++ b/source/_posts/2016/2016-12-09-jak-se-vyporadat-s-hejty-v-komentarich.md
@@ -5,6 +5,8 @@ perex: "Na to se mě včera zeptal už asi pátý člověk. Jak se vypořádat s
 deprecated: true
 deprecated_since: "August 2017"
 deprecated_message: "This post is available only in Czech and whole website was moved to English."
+
+lang: cs
 ---
 
 Tenhle proces jsem se učil 1 rok jako maintainer [ApiGenu](github.com/apigen/apigen), kdy jsem s desítkami lidí vedl online-hate-wars a zjistil, že to nikam nevede. Pak jsem zkoušel jiné cesty. Úspěšnější.

--- a/source/_posts/2017/2017-01-10-jak-psat-zajimave-inzeraty-pro-ajtaky.md
+++ b/source/_posts/2017/2017-01-10-jak-psat-zajimave-inzeraty-pro-ajtaky.md
@@ -7,6 +7,8 @@ perex: '''
 deprecated: true
 deprecated_since: "August 2017"
 deprecated_message: "This post is available only in Czech and whole website was moved to English."
+
+lang: cs
 ---
 
 

--- a/source/_posts/2017/2017-01-15-7-rad-ktere-bych-si-dal-pred-odchodem-na-vysokou-skolu.md
+++ b/source/_posts/2017/2017-01-15-7-rad-ktere-bych-si-dal-pred-odchodem-na-vysokou-skolu.md
@@ -9,6 +9,8 @@ perex: '''
 deprecated: true
 deprecated_since: "August 2017"
 deprecated_message: "This post is available only in Czech and whole website was moved to English."
+
+lang: cs
 ---
 
 **Disclaimer: Moje závěry plynou ze zkušeností ze studia v Brně na FIT VUT a FSS MUNI a kolem 300 rozhovorů se spolužáky a (po)vysokoškoláky z Brna, Prahy a Liberce. Pokud je to na tvé škole jinak, budu rád za tvůj pohled a tipy.**

--- a/source/_snippets/post/singlePostPreview.latte
+++ b/source/_snippets/post/singlePostPreview.latte
@@ -1,0 +1,19 @@
+{*{var $postYear = $post->getDateInFormat('Y')}*}
+{*{if $postYear != date('Y') && !isset($dateLines[$postYear])}*}
+    {*<div class="col-md-12 yearLine clearfix" id="year-{$postYear}">*}
+        {*<br>*}
+        {*<br>*}
+        {*{$postYear}*}
+        {*{var $dateLines[$postYear] = $postYear}*}
+    {*</div>*}
+{*{/if}*}
+
+<article class="text-left col-md-6">
+    <h2>
+        <a href="/{$post['relativeUrl']}/">
+            {$post['title']|noescape}
+        </a>
+    </h2>
+
+    {include "postMetadataLine", post => $post}
+</article>

--- a/source/czech-posts.latte
+++ b/source/czech-posts.latte
@@ -1,0 +1,19 @@
+---
+layout: default
+title: "Czech Posts"
+id: blog
+---
+
+{block content}
+    <div class="container-fluid" id="blog">
+        <h1>Czech Posts</h1>
+
+        <div class="row">
+            {foreach $posts as $post}
+                {continueIf ! isset($post['deprecated']) || ! isset($post['lang'])}
+
+                {include "singlePostPreview", post => $post}
+            {/foreach}
+        </div>
+    </div>
+{/block}

--- a/source/deprecated-posts.latte
+++ b/source/deprecated-posts.latte
@@ -1,0 +1,19 @@
+---
+layout: default
+title: "Deprecated Posts"
+id: blog
+---
+
+{block content}
+    <div class="container-fluid" id="blog">
+        <h1>Deprecated Posts</h1>
+
+        <div class="row">
+            {foreach $posts as $post}
+                {continueIf ! isset($post['deprecated']) || isset($post['lang'])}
+
+                {include "singlePostPreview", post => $post}
+            {/foreach}
+        </div>
+    </div>
+{/block}

--- a/source/index.latte
+++ b/source/index.latte
@@ -45,10 +45,23 @@ id: blog
 
         <br>
 
-        <p class="text-center">
-            <strong>Do you want to be first to know about new posts?</strong>
+
+        <div class="text-center mt-4 mb-5">
+            <p>
+                <strong>Could not find post that was here before?</strong>
+            </p>
+            <p>
+                See <a href="/deprecated-posts">deprecated posts</a>
+                or <a href="/czech-posts">Czech posts</a>
+            </p>
+        </div>
+
+        <div class="text-center mt-5 mb-4">
+            <p>
+                <strong>Do you want to be first to know about new posts?</strong>
+            </p>
             {include subscribe}
-        </p>
+        </div>
     </div>
 {/block}
 


### PR DESCRIPTION
### Reasoning

Many people still comment posts that are deprecated or in Czech. But those are hidden in main page list and it's impossible to find them again.

**This fixes that**

![image](https://user-images.githubusercontent.com/924196/35676222-4a021d0a-074b-11e8-8370-f5a90bd294be.png)

---

![image](https://user-images.githubusercontent.com/924196/35676247-5bb78dfa-074b-11e8-845a-eaaf6bbd33d6.png)
