### PR TITLE
Fixed refactoring example for Rector

### DIFF
--- a/source/_posts/2018/2018-02-19-rector-part-1-what-and-how.md
+++ b/source/_posts/2018/2018-02-19-rector-part-1-what-and-how.md
@@ -81,16 +81,16 @@ class LectureController extends BaseController
     /**
      * @var LoggerInterface
      */
-    private $loggerInterface;
+    private $logger;
 
-    public function __construct(LoggerInterface $loggerInterface)
+    public function __construct(LoggerInterface $logger)
     {
-        $this->loggerInterface = $loggerInterface;
+        $this->logger = $logger;
     }
 
     public function listAction()
     {
-        $this->loggerInterface->log('it happened!');
+        $this->logger->log('it happened!');
     }
 }
 ```


### PR DESCRIPTION
Argument and attribute name should be named `$logger`, not `$loggerInterface` since it's concrete implementation. And there was fatal error - calling `log()` on `null` ;-)