### PR TITLE
move fix CTA under the post, where are some errors

### DIFF
--- a/source/_layouts/post.twig
+++ b/source/_layouts/post.twig
@@ -95,9 +95,16 @@
                     </div>
                 {% endif %}
 
-                <a name="comments"></a>
+                <div class="card mb-5 small">
+                    <div class="card-body text-center">
+                        <a href="{{ post|githubEditPostUrl }}" class="btn btn-info btn-sm">
+                            <em class="fas fa-fw fa-edit"></em>
+                            Typo? Fix me, please
+                        </a>
+                    </div>
+                </div>
 
-                <h3>What do you think?</h3>
+                <a name="comments"></a>
 
                 {% include "_snippets/disqusComments.twig" with { 'post': post } %}
             </div>

--- a/source/_snippets/post/postMetadataLine.twig
+++ b/source/_snippets/post/postMetadataLine.twig
@@ -18,7 +18,7 @@
 
     {% if showPullRequestLink is defined %}
         <li class="list-inline-item">
-            <em class="fas fa-fw fa-pencil"></em>
+            <em class="fas fa-fw fa-edit"></em>
             <a href="{{ post|githubEditPostUrl }}">Typo? Fix me, please</a>
         </li>
     {% endif %}


### PR DESCRIPTION
Most people find typos *after* reading the post, so having CTA only in the top makes no sense. I keep it there for quick edits and back compatbility, but also add under the post.

Closes #442 


### Before

![image](https://user-images.githubusercontent.com/924196/44712345-d340b780-aab0-11e8-9602-5e191ca136dc.png)


### After

![image](https://user-images.githubusercontent.com/924196/44712329-c7ed8c00-aab0-11e8-9bba-652edf9fad80.png)
