### PR TITLE
Fix a typo in article

### DIFF
--- a/source/_posts/2018/2018-09-17-7-tips-to-write-exceptions-everyone-will-love.md
+++ b/source/_posts/2018/2018-09-17-7-tips-to-write-exceptions-everyone-will-love.md
@@ -97,7 +97,7 @@ You probably noticed it, because there are 3 lines of code and they get all your
 <blockquote class="blockquote">
      <em>Filter class  VeryLongNamespace\InNestedNamespace\WithMissingClassInTheEnd was not found</em>
 </blockquote>
-*Filer class " VeryLongNamespace\InNestedNamespace\WithMissingClassInTheEnd" was not found*
+*Filter class " VeryLongNamespace\InNestedNamespace\WithMissingClassInTheEnd" was not found*
 
 **Use quotes around every argument:**
 


### PR DESCRIPTION
Fix a typo in "7 Tips to Write Exceptions Everyone Will Love" article. You wrote "Filer" instead of "Filter".