### PR TITLE
Remove unnecessary quotation mark

### DIFF
--- a/source/_posts/2018/2018-09-17-7-tips-to-write-exceptions-everyone-will-love.md
+++ b/source/_posts/2018/2018-09-17-7-tips-to-write-exceptions-everyone-will-love.md
@@ -246,7 +246,7 @@ vendor/bin/ecs check src --level laravel
 ```
 
 <blockquote class="blockquote">
-     <em>"Laravel" level was not found"</em>
+     <em>"Laravel" level was not found</em>
 </blockquote>
 
 - Is incorrectly loaded?


### PR DESCRIPTION
Remove unnecessary quotation mark from "7 Tips to Write Exceptions Everyone Will Love" article.