### PR TITLE
Added strict_types=1 to code examples

### DIFF
--- a/source/_posts/2018/2018-11-15-how-to-get-php-74-typed-properties-to-your-code-in-few-seconds.md
+++ b/source/_posts/2018/2018-11-15-how-to-get-php-74-typed-properties-to-your-code-in-few-seconds.md
@@ -32,7 +32,7 @@ Here we can see that `$count` is an `int` number.
 **In PHP 7.4** we could change this code to get a [strict typing](https://wiki.php.net/rfc/typed_properties_v2):
 
 ```diff
- <?php
+ <?php declare(strict_types=1);
 
  final class SomeClass
  {
@@ -87,7 +87,7 @@ final class SomeClass
 In PHP 8 or 9 this might come:
 
 ```diff
- <?php
+ <?php declare(strict_types=1);
 
  final class SomeClass
  {
@@ -114,6 +114,8 @@ Yeah, right, I made a promise - I'll get back to nearer future with *typed prope
 Let's say we're thinking about the future and adding all `@var` annotations we can. Is that enough? You'd still have to do these diffs manually:
 
 ```diff
+ <?php declare(strict_types=1);
+ 
  final class SomeClass
  {
 -    /**


### PR DESCRIPTION
I think there should be `declare(strict_types=1);` in all code examples which are using typed properties since you need to declare the strict type to enforce type checking. Same as parameter type hints.