### PR TITLE
Fix `json_decode()` arguments

### DIFF
--- a/source/_posts/2018/2018-08-16-whats-new-in-php-73-in-30-seconds-in-diffs.md
+++ b/source/_posts/2018/2018-08-16-whats-new-in-php-73-in-30-seconds-in-diffs.md
@@ -149,14 +149,14 @@ But in case of that smelly (3rd party) code, there is a help:
 
 ```diff
 -json_decode($json);
-+json_decode($json, null, null, JSON_THROW_ON_ERROR);
++json_decode($json, false, 512, JSON_THROW_ON_ERROR);
 ```
 
 So you'll be able to do:
 
 ```php
 try {
-    return json_decode($json, null, null, JSON_THROW_ON_ERROR);
+    return json_decode($json, false, 512, JSON_THROW_ON_ERROR);
 } catch (JsonException $exception) {
     // ...
 }


### PR DESCRIPTION
Because `json_decode('{}', null, null);` gives

> PHP Warning:  json_decode(): Depth must be greater than zero