### PR TITLE
Fix invalid RSS website link

### DIFF
--- a/source/rss.twig
+++ b/source/rss.twig
@@ -9,7 +9,7 @@ outputPath: rss.xml
 >
     <channel>
         <title>Tomas Votruba writes about PHP and education</title>
-        <link>{{ site_url }}/blog/</link>
+        <link>{{ site_url }}/</link>
         <description>PHP, Communities and Communication posts by Tomas Votruba</description>
         <pubDate>{{ "now"|date('r') }}</pubDate>
         <atom:link href="{{ site_url }}/rss.xml" rel="self" type="application/rss+xml" />

--- a/statie.yaml
+++ b/statie.yaml
@@ -29,6 +29,7 @@ parameters:
 
     redirects:
         # old url → new url
+        /blog: '/'
         /little-books: '/clusters'
         /about: '/clusters'
         /mentoring-and-lectures: '/mission'


### PR DESCRIPTION
Redirect `/blog/` -> `/` might be useful too