### PR TITLE
Promote the use of mockBuilder()

### DIFF
--- a/source/_posts/2019/2019-11-04-still-on-phpunit-4-come-to-phpunit-8-together-in-a-day.md
+++ b/source/_posts/2019/2019-11-04-still-on-phpunit-4-come-to-phpunit-8-together-in-a-day.md
@@ -95,7 +95,7 @@ Unless you're upgrading 10 test files, of course. But in the rest of the case, t
 
 ## 3. PHPUnit 4 to 5
 
-### From `getMock()` to `getMock()`
+### From `getMock()` to `getMockBuilder()`
 
 ```diff
  <?php

--- a/source/_posts/2019/2019-11-04-still-on-phpunit-4-come-to-phpunit-8-together-in-a-day.md
+++ b/source/_posts/2019/2019-11-04-still-on-phpunit-4-come-to-phpunit-8-together-in-a-day.md
@@ -95,7 +95,7 @@ Unless you're upgrading 10 test files, of course. But in the rest of the case, t
 
 ## 3. PHPUnit 4 to 5
 
-### From `getMock()` to `createMock()`
+### From `getMock()` to `getMock()`
 
 ```diff
  <?php
@@ -105,7 +105,7 @@ Unless you're upgrading 10 test files, of course. But in the rest of the case, t
      public function test()
      {
 -        $someClassMock = $this->getMock('SomeClass');
-+        $someClassMock = $this->buildMock('SomeClass');
++        $someClassMock = $this->getMockBuilder('SomeClass')->getMock();
      }
  }
 ```


### PR DESCRIPTION
Since createMock might not be available, but mockBuilder has for a while (and allows for customizing the mocked result with disabling ctors / only specifying certain methods et al)