### PR TITLE
Standardize the VAT formula through the method evolution

### DIFF
--- a/source/_posts/2018/2018-06-14-collector-pattern-for-dummies.md
+++ b/source/_posts/2018/2018-06-14-collector-pattern-for-dummies.md
@@ -18,7 +18,7 @@ class PriceCalculator
     public function calculate(Product $product): float
     {
         // compute vat
-        $price = $product->getPrice() * (1 + $vat);
+        $price = $product->getPrice() * 1.15;
 
         return $price;
     }
@@ -33,7 +33,7 @@ Then we decide to have 50 % discount for admins:
      public function calculate(Product $product): float
      {
          // compute vat
-         $price = $product->getPrice() * (1 + $vat);
+         $price = $product->getPrice() * 1.15;
 
 +        // discount for admin
 +        if ($this->currentUser->getRole() === 'admin') {
@@ -53,7 +53,7 @@ And another 20 % discount for students:
      public function calculate(Product $product): float
      {
          // compute vat
-         $price = $product->getPrice() * 1.21;
+         $price = $product->getPrice() * 1.15;
 
          // discount for admin
          if ($this->currentUser->getRole() === 'admin') {


### PR DESCRIPTION
The first version of the `calculate()` method had undefined variable. Then the formula was changing even though the change was not needed to make the point. But when I was reading the article I got fixated on the VAT formula change :)