### PR TITLE
feat: add link for tools without blog post

### DIFF
--- a/resources/views/tools.blade.php
+++ b/resources/views/tools.blade.php
@@ -64,6 +64,11 @@
                                     <span class="ps-2 pe-2">•</span>
                                     <a href="{{ $tool->getPost() }}">Read&nbsp;more in a post</a>
                                 @endif
+
+                                @if ($tool->getRepositoryLink())
+                                    <span class="ps-2 pe-2">•</span>
+                                    <a href="{{ $tool->getRepositoryLink() }}">Checkout repository</a>
+                                @endif
                             </p>
 
                             <br>

--- a/src/Repository/ToolRepository.php
+++ b/src/Repository/ToolRepository.php
@@ -80,11 +80,12 @@ PHPSTAN
             'Composer Dependency Analyser',
             'When you reach PHPStan level 2/3',
             'Detect unused dependencies, transitional dependencies, missing classes and more',
-            '',
+            null,
             'composer require shipmonk/composer-dependency-analyser --dev',
             [
                 'Run' => 'vendor/bin/composer-dependency-analyser',
-            ]
+            ],
+            repositoryLink: 'https://github.com/shipmonk-rnd/composer-dependency-analyser',
         );
 
         $tools[] = new Tool(
@@ -152,7 +153,8 @@ PHPSTAN
             [
                 'Analyse' => 'vendor/bin/behastan analyze',
             ],
-            isNew: true
+            isNew: true,
+            repositoryLink: 'https://github.com/rectorphp/behastan',
         );
 
         return $tools;

--- a/src/ValueObject/Tool.php
+++ b/src/ValueObject/Tool.php
@@ -21,6 +21,7 @@ final readonly class Tool
         private bool $isPhpstanExtension = false,
         private ?string $phpstanContents = null,
         private bool $isNew = false,
+        private ?string $repositoryLink = null,
     ) {
         Assert::allString(array_keys($tryCommands));
         Assert::allString($tryCommands);
@@ -77,5 +78,10 @@ final readonly class Tool
     public function isNew(): bool
     {
         return $this->isNew;
+    }
+
+    public function getRepositoryLink(): ?string
+    {
+        return $this->repositoryLink;
     }
 }


### PR DESCRIPTION
Fixes GH-1532:

- GH-1532

I used the text “Checkout repository” without mentioning GitHub since some packages may be hosted elsewhere.
